### PR TITLE
Increase the trimmed height/width by 1px

### DIFF
--- a/src/trim.ts
+++ b/src/trim.ts
@@ -49,8 +49,8 @@ function trim(c: HTMLCanvasElement) {
     }
   }
 
-  const trimHeight = bound.bottom! - bound.top!,
-    trimWidth = bound.right! - bound.left!,
+  const trimHeight = bound.bottom! - bound.top! + 1,
+    trimWidth = bound.right! - bound.left! + 1,
     trimmed = ctx.getImageData(bound.left!, bound.top!, trimWidth, trimHeight);
 
   copy.canvas.width = trimWidth;


### PR DESCRIPTION
`trim()` is based on [this gist](https://gist.github.com/remy/784508). There are a few comments on the gist noting that it takes an extra pixel off the right and bottom edges, this PR ports one of the suggested fixes for it.

Fixes #1.

