### PR TITLE
Smooth the appearance of wide borders

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,27 +8,17 @@ function stickerify(
   const canvas = document.createElement("canvas"),
     ctx = canvas.getContext("2d")!;
 
-  const offsetArr = [
-      [-1, -1],
-      [0, -1],
-      [1, -1],
-      [-1, 0],
-      [1, 0],
-      [-1, 1],
-      [0, 1],
-      [1, 1],
-    ],
-    x = thickness + 1, // 1px buffer in case of rounding errors etc.
+  const x = thickness + 1, // 1px buffer in case of rounding errors etc.
     y = thickness + 1;
 
   canvas.width = img.width + 2 * x;
   canvas.height = img.height + 2 * y;
 
-  for (let i = 0; i < offsetArr.length; i++)
+  for (let angle = 0; angle < 360; angle += 10)
     ctx.drawImage(
       img,
-      offsetArr[i][0] * thickness + x,
-      offsetArr[i][1] * thickness + y
+      thickness * Math.sin( ( Math.PI * 2 * angle ) / 360 ) + x,
+      thickness * Math.cos( ( Math.PI * 2 * angle ) / 360 ) + y
     );
 
   ctx.globalCompositeOperation = "source-in";

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,8 @@ import trim from "./trim";
 function stickerify(
   img: HTMLImageElement,
   thickness: number = 1,
-  fillStyle: string | CanvasGradient | CanvasPattern = "white"
+  fillStyle: string | CanvasGradient | CanvasPattern = "white",
+  samples: number = 36
 ) {
   const canvas = document.createElement("canvas"),
     ctx = canvas.getContext("2d")!;
@@ -14,7 +15,7 @@ function stickerify(
   canvas.width = img.width + 2 * x;
   canvas.height = img.height + 2 * y;
 
-  for (let angle = 0; angle < 360; angle += 10)
+  for (let angle = 0; angle < 360; angle += 360 / samples) {
     ctx.drawImage(
       img,
       thickness * Math.sin( ( Math.PI * 2 * angle ) / 360 ) + x,


### PR DESCRIPTION
This PR modifies the offset algorithm to make wider borders appear smoother. It does this in two ways:

- More offset samples. Instead of the current 8 samples, it now does 36.
- Ensuring that the sample positions are always the same distance from the origin. The current method effectively moves the image along a square path around the origin, this new method moves the image in a circular path, instead.

This is a particularly noticeable improvement on pictures with fine details.

Images with excessively large borders will still see some artefacts, so this PR also adds a `samples` parameter to `stickerify()`, allowing the number of samples to be increased when needed.

## Before / After

### 10px Border

<img src="https://user-images.githubusercontent.com/352291/140631951-dd585087-4490-4ff3-9bfb-1ea869d356f4.png" width="380" /> <img src="https://user-images.githubusercontent.com/352291/140631946-200e0e86-460f-4888-967b-f43c5c0d7eb6.png" width="380" />

### 100px Border
<img src="https://user-images.githubusercontent.com/352291/140631952-863b5f16-24b0-4602-b59c-4d20efea2b65.png" width="380" /> <img src="https://user-images.githubusercontent.com/352291/140631949-d0944659-3a89-4a7b-b510-900e45f3f375.png" width="380" />

### 100px Border with 360 samples
![after-100-samples-360](https://user-images.githubusercontent.com/352291/140631948-f7dbf330-c78f-40ee-a2a0-3ea172949674.png)
